### PR TITLE
Integrate small language model

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,13 +13,20 @@ local JSON file. During idle periods the engine generates autonomous
 - **Idle thinking**: the engine reflects on the last message when no input has
   been received for a configurable period.
 - **Command line interface** with subcommands to chat and inspect memory.
+- **Model-based responses** powered by a small open-source language model.
 
 ## Usage
 
-Run the chat interface:
+Run the chat interface (optionally specifying a HuggingFace model):
 
 ```bash
-python -m forgeengine.cli chat
+python -m forgeengine.cli --model Qwen/Qwen1.5-0.5B chat
+```
+
+During testing or on resource-limited systems you can use a tiny model:
+
+```bash
+python -m forgeengine.cli --model sshleifer/tiny-gpt2 chat
 ```
 
 View stored interactions:

--- a/forgeengine/cli.py
+++ b/forgeengine/cli.py
@@ -6,7 +6,11 @@ from .engine import NarrativeEngine
 
 
 def run_chat(args: argparse.Namespace) -> None:
-    engine = NarrativeEngine(memory_path=args.memory, think_interval=args.think)
+    engine = NarrativeEngine(
+        memory_path=args.memory,
+        think_interval=args.think,
+        model_name=args.model,
+    )
     engine._reset_timer()
     print("Type 'quit' or 'exit' to stop.")
     try:
@@ -22,19 +26,31 @@ def run_chat(args: argparse.Namespace) -> None:
 
 
 def show_memory(args: argparse.Namespace) -> None:
-    engine = NarrativeEngine(memory_path=args.memory, think_interval=args.think)
+    engine = NarrativeEngine(
+        memory_path=args.memory,
+        think_interval=args.think,
+        model_name=args.model,
+    )
     for item in engine.store.data.interactions:
         print(f"{item['timestamp']}: {item['user']} -> {item['response']}")
 
 
 def show_events(args: argparse.Namespace) -> None:
-    engine = NarrativeEngine(memory_path=args.memory, think_interval=args.think)
+    engine = NarrativeEngine(
+        memory_path=args.memory,
+        think_interval=args.think,
+        model_name=args.model,
+    )
     for evt in engine.store.data.events:
         print(f"{evt['timestamp']}: {evt['event']}")
 
 
 def show_glossary(args: argparse.Namespace) -> None:
-    engine = NarrativeEngine(memory_path=args.memory, think_interval=args.think)
+    engine = NarrativeEngine(
+        memory_path=args.memory,
+        think_interval=args.think,
+        model_name=args.model,
+    )
     for word, count in sorted(engine.store.data.glossary.items()):
         print(f"{word}: {count}")
 
@@ -44,6 +60,11 @@ def build_parser() -> argparse.ArgumentParser:
     parser.add_argument("--memory", default="memory.json", help="Memory file path")
     parser.add_argument(
         "--think", type=int, default=10, help="Seconds of idle before thinking"
+    )
+    parser.add_argument(
+        "--model",
+        default="Qwen/Qwen1.5-0.5B",
+        help="HuggingFace model name to use for generation",
     )
 
     sub = parser.add_subparsers(dest="command")

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,3 @@
 pytest
+transformers>=4.39.0
+torch>=2.1.0

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -3,7 +3,10 @@ from forgeengine.engine import NarrativeEngine
 
 
 def test_engine_response(tmp_path):
-    engine = NarrativeEngine(memory_path=str(tmp_path / "mem.json"))
+    engine = NarrativeEngine(
+        memory_path=str(tmp_path / "mem.json"),
+        model_name="sshleifer/tiny-gpt2",
+    )
     response = engine.respond("hello")
     assert "hello" in response
 


### PR DESCRIPTION
## Summary
- integrate a Transformers-based language model into the NarrativeEngine
- expose `--model` option in the CLI
- document model usage in the README
- update tests to use a tiny model
- add transformers and torch dependencies

## Testing
- `pip install -q --no-cache-dir -r requirements.txt`
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684d98e2e99883239cb77dd6b7f67791