### PR TITLE
Improve model loading and add setup wizard

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,3 +45,9 @@ forgengine memory
 
 Other subcommands include `events` and `glossary`. Use `--help` for details.
 
+### Interactive setup
+
+Running `forgengine` with no existing configuration walks you through a short
+setup. Your choices are stored in `~/.forgengine.json` and reused on subsequent
+runs. Use `--setup` at any time to reconfigure.
+

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,13 @@
+import sys, pathlib, json
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+from forgeengine.cli import load_config
+
+
+def test_load_config_file(tmp_path):
+    cfg = tmp_path / "cfg.json"
+    cfg.write_text(json.dumps({"memory": "x.json", "think": 1, "model": "m", "max_tokens": 5}))
+    data = load_config(str(cfg))
+    assert data["memory"] == "x.json"
+    assert data["think"] == 1
+
+


### PR DESCRIPTION
## Summary
- add interactive configuration for the CLI with `--setup`
- automatically save and reuse options in `~/.forgengine.json`
- implement fallback model logic in `NarrativeEngine`
- expose config helper to tests
- document the setup wizard in README

## Testing
- `pip install -e .` *(fails: Operation cancelled by user)*
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684deacbccc883238c0b3ef5d5ae773a