### PR TITLE
Improve local model discovery and adapter loading

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,3 +45,13 @@ forgengine memory
 
 Other subcommands include `events` and `glossary`. Use `--help` for details.
 
+### Interactive setup
+
+Running `forgengine` with no existing configuration walks you through a short
+setup. It scans for local HuggingFace models and lets you pick one, storing your
+choice along with other options in `~/.forgengine.json`. Use `--setup` at any
+time to reconfigure. A `models` subcommand lists discovered models.
+
+Optionally specify an adapter path with `--adapter` to apply LoRA weights if the
+`peft` package is available.
+

--- a/forgeengine/cli.py
+++ b/forgeengine/cli.py
@@ -1,8 +1,70 @@
 """Command line interface for the Narrative Engine."""
 
 import argparse
+import json
+import os
+from typing import List
 
-from .engine import NarrativeEngine
+from .engine import NarrativeEngine, PRIMARY_MODEL
+
+
+CONFIG_PATH = os.path.expanduser("~/.forgengine.json")
+
+
+def discover_local_models(directories: List[str] | None = None) -> List[str]:
+    """Return possible local model directories."""
+    if directories is None:
+        directories = [
+            os.path.expanduser("~/.cache/huggingface/hub"),
+            os.path.expanduser("~/models"),
+            os.path.join(os.getcwd(), "models"),
+        ]
+    found: List[str] = []
+    for base in directories:
+        if not os.path.isdir(base):
+            continue
+        for root, _dirs, files in os.walk(base):
+            if "config.json" in files:
+                found.append(root)
+    return sorted(found)
+
+
+def load_config(path: str = CONFIG_PATH, force_setup: bool = False) -> dict:
+    """Load configuration or run interactive setup."""
+    path = os.path.expanduser(path)
+    if force_setup or not os.path.exists(path):
+        print("Setting up ForgeEngine configuration.")
+        memory = input("Memory file path [memory.json]: ") or "memory.json"
+        think = input("Think interval seconds [10]: ")
+        think = int(think) if think else 10
+
+        discovered = discover_local_models()
+        default_model = discovered[0] if discovered else PRIMARY_MODEL
+        if discovered:
+            print("Available local models:")
+            for idx, name in enumerate(discovered, 1):
+                print(f"  {idx}. {name}")
+        model = input(f"Model name [{default_model}]: ") or default_model
+
+        tokens = input("Max tokens [512]: ")
+        tokens = int(tokens) if tokens else 512
+        adapter = input("Adapter path [none]: ") or ""
+        config = {
+            "memory": memory,
+            "think": think,
+            "model": model,
+            "max_tokens": tokens,
+            "adapter": adapter,
+        }
+        save = input("Save configuration for next time? [Y/n]: ").strip().lower()
+        if not save or save.startswith("y"):
+            with open(path, "w", encoding="utf-8") as fh:
+                json.dump(config, fh, indent=2)
+            print(f"Configuration saved to {path}")
+        return config
+
+    with open(path, "r", encoding="utf-8") as fh:
+        return json.load(fh)
 
 
 def run_chat(args: argparse.Namespace) -> None:
@@ -11,6 +73,7 @@ def run_chat(args: argparse.Namespace) -> None:
         think_interval=args.think,
         model_name=args.model,
         max_tokens=args.max_tokens,
+        adapter_path=args.adapter,
     )
     engine._reset_timer()
     print("Type 'quit' or 'exit' to stop.")
@@ -32,6 +95,7 @@ def show_memory(args: argparse.Namespace) -> None:
         think_interval=args.think,
         model_name=args.model,
         max_tokens=args.max_tokens,
+        adapter_path=args.adapter,
     )
     for item in engine.store.data.interactions:
         print(f"{item['timestamp']}: {item['user']} -> {item['response']}")
@@ -43,6 +107,7 @@ def show_events(args: argparse.Namespace) -> None:
         think_interval=args.think,
         model_name=args.model,
         max_tokens=args.max_tokens,
+        adapter_path=args.adapter,
     )
     for evt in engine.store.data.events:
         print(f"{evt['timestamp']}: {evt['event']}")
@@ -54,27 +119,38 @@ def show_glossary(args: argparse.Namespace) -> None:
         think_interval=args.think,
         model_name=args.model,
         max_tokens=args.max_tokens,
+        adapter_path=args.adapter,
     )
     for word, count in sorted(engine.store.data.glossary.items()):
         print(f"{word}: {count}")
 
 
-def build_parser() -> argparse.ArgumentParser:
+def list_models(args: argparse.Namespace) -> None:
+    for path in discover_local_models():
+        print(path)
+
+
+def build_parser(config: dict) -> argparse.ArgumentParser:
     parser = argparse.ArgumentParser(description="Narrative Engine CLI")
-    parser.add_argument("--memory", default="memory.json", help="Memory file path")
+    parser.add_argument("--memory", default=config.get("memory", "memory.json"), help="Memory file path")
     parser.add_argument(
-        "--think", type=int, default=10, help="Seconds of idle before thinking"
+        "--think", type=int, default=config.get("think", 10), help="Seconds of idle before thinking"
     )
     parser.add_argument(
         "--model",
-        default="mradermacher/Uncensored_DeepSeek_R1_Distill_Qwen_1.5B_safetensors_finetune_2-GGUF",
+        default=config.get("model", PRIMARY_MODEL),
         help="HuggingFace model name to use for generation",
     )
     parser.add_argument(
         "--max-tokens",
         type=int,
-        default=512,
+        default=config.get("max_tokens", 512),
         help="Maximum tokens to generate for each response",
+    )
+    parser.add_argument(
+        "--adapter",
+        default=config.get("adapter", ""),
+        help="Optional adapter or LoRA weights path",
     )
 
     sub = parser.add_subparsers(dest="command")
@@ -90,12 +166,25 @@ def build_parser() -> argparse.ArgumentParser:
     glo = sub.add_parser("glossary", help="Show learned glossary")
     glo.set_defaults(func=show_glossary)
 
+    lm = sub.add_parser("models", help="List available local models")
+    lm.set_defaults(func=list_models)
+
     return parser
 
 
 def main() -> None:
-    parser = build_parser()
-    args = parser.parse_args()
+    base = argparse.ArgumentParser(add_help=False)
+    base.add_argument("--config", default=CONFIG_PATH)
+    base.add_argument("--setup", action="store_true")
+    known, remaining = base.parse_known_args()
+
+    config = load_config(known.config, force_setup=known.setup)
+
+    parser = build_parser(config)
+    parser.add_argument("--config", default=known.config, help=argparse.SUPPRESS)
+    parser.add_argument("--setup", action="store_true", help="Run interactive setup")
+
+    args = parser.parse_args(remaining)
     if not hasattr(args, "func"):
         parser.print_help()
         return

--- a/forgeengine/engine.py
+++ b/forgeengine/engine.py
@@ -1,16 +1,34 @@
+import os
 import threading
 import time
 from datetime import datetime
 from typing import Any, Dict, Optional
 
 try:
-    from transformers import AutoModelForCausalLM, AutoTokenizer, pipeline
+    from transformers import (
+        AutoModel,
+        AutoModelForCausalLM,
+        AutoTokenizer,
+        pipeline,
+    )
 except Exception:  # pragma: no cover - optional dependency
+    AutoModel = None  # type: ignore
     AutoModelForCausalLM = None  # type: ignore
     AutoTokenizer = None  # type: ignore
     pipeline = None  # type: ignore
 
+try:
+    from peft import PeftModel
+except Exception:  # pragma: no cover - optional dependency
+    PeftModel = None  # type: ignore
+
 from .memory import MemoryStore
+
+
+PRIMARY_MODEL = (
+    "mradermacher/Uncensored_DeepSeek_R1_Distill_Qwen_1.5B_safetensors_finetune_2-GGUF"
+)
+FALLBACK_MODEL = "deepseek-ai/DeepSeek-R1-Distill-Qwen-1.5B"
 
 
 class NarrativeEngine:
@@ -20,13 +38,15 @@ class NarrativeEngine:
         self,
         memory_path: str = "memory.json",
         think_interval: int = 10,
-        model_name: str = "mradermacher/Uncensored_DeepSeek_R1_Distill_Qwen_1.5B_safetensors_finetune_2-GGUF",
+        model_name: str = PRIMARY_MODEL,
         max_tokens: int = 512,
+        adapter_path: str | None = None,
     ) -> None:
         self.store = MemoryStore(memory_path)
         self.think_interval = think_interval
         self.model_name = model_name
         self.max_tokens = max_tokens
+        self.adapter_path = adapter_path
         self._timer: Optional[threading.Timer] = None
         self._pipeline = self._load_model()
 
@@ -34,13 +54,38 @@ class NarrativeEngine:
         if not AutoModelForCausalLM:
             print("Warning: transformers not installed. Falling back to echo mode.")
             return None
-        try:
-            tokenizer = AutoTokenizer.from_pretrained(self.model_name)
-            model = AutoModelForCausalLM.from_pretrained(self.model_name)
-            return pipeline("text-generation", model=model, tokenizer=tokenizer)
-        except Exception as exc:
-            print(f"Warning: failed to load model {self.model_name}: {exc}. Using echo mode.")
+
+        model = None
+        tokenizer = None
+        for name in [self.model_name, FALLBACK_MODEL]:
+            try:
+                tokenizer = AutoTokenizer.from_pretrained(name, local_files_only=True)
+                model = AutoModelForCausalLM.from_pretrained(name, local_files_only=True)
+                print(f"Loaded local model {name}")
+                break
+            except Exception as exc_local:
+                print(f"Local load failed for {name}: {exc_local}")
+                try:
+                    tokenizer = AutoTokenizer.from_pretrained(name)
+                    model = AutoModelForCausalLM.from_pretrained(name)
+                    print(f"Loaded remote model {name}")
+                    break
+                except Exception as exc_remote:
+                    print(f"Remote load failed for {name}: {exc_remote}")
+                    model = None
+
+        if not model or not tokenizer:
+            print("Using echo mode.")
             return None
+
+        if self.adapter_path and PeftModel and os.path.exists(self.adapter_path):
+            try:
+                model = PeftModel.from_pretrained(model, self.adapter_path)
+                print(f"Loaded adapter from {self.adapter_path}")
+            except Exception as exc:
+                print(f"Failed to load adapter {self.adapter_path}: {exc}")
+
+        return pipeline("text-generation", model=model, tokenizer=tokenizer)
 
     def _reset_timer(self) -> None:
         if self._timer:

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -1,0 +1,22 @@
+import sys, pathlib, json
+sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+from forgeengine.cli import load_config, discover_local_models
+
+
+def test_load_config_file(tmp_path):
+    cfg = tmp_path / "cfg.json"
+    cfg.write_text(json.dumps({"memory": "x.json", "think": 1, "model": "m", "max_tokens": 5}))
+    data = load_config(str(cfg))
+    assert data["memory"] == "x.json"
+    assert data["think"] == 1
+    assert "adapter" not in data
+
+
+def test_discover_local_models(tmp_path):
+    assert discover_local_models([str(tmp_path)]) == []
+    model_dir = tmp_path / "model"
+    model_dir.mkdir()
+    (model_dir / "config.json").write_text("{}")
+    assert discover_local_models([str(tmp_path)]) == [str(model_dir)]
+
+


### PR DESCRIPTION
## Summary
- add helper `discover_local_models` with new `models` CLI command
- interactive setup now lists found models and stores an optional adapter path
- engine supports adapters via `peft` and searches locally before remote
- document new options in README
- expand CLI tests

## Testing
- `pytest -q`
- `pip install -e .` *(fails: Operation cancelled by user)*

------
https://chatgpt.com/codex/tasks/task_b_684deacbccc883238c0b3ef5d5ae773a