### PR TITLE
Improve NarrativeEngine reliability

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,3 @@
+## Unreleased
+- Require models to load successfully and remove echo fallback.
+- Added virtual environment installer script and installation docs.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,8 @@ This repository contains a proof-of-concept narrative engine that maintains
 persistent memory of conversations and events. The system can run in an
 interactive chat mode from the command line, storing all interactions in a
 local JSON file. During idle periods the engine generates autonomous
-"thoughts" that are also recorded.
+"thoughts" that are also recorded. If the configured model cannot be loaded the
+engine now stops with a clear error instead of falling back to an echo mode.
 
 ## Features
 
@@ -14,6 +15,18 @@ local JSON file. During idle periods the engine generates autonomous
   been received for a configurable period.
 - **Command line interface** with subcommands to chat and inspect memory.
 - **Model-based responses** powered by a small open-source language model.
+
+## Installation
+
+Run the bundled `install.sh` script to create a virtual environment and install
+dependencies in editable mode:
+
+```bash
+./install.sh
+```
+
+Activate the environment with `source .venv/bin/activate` and you are ready to
+run the `forgengine` command.
 
 ## Usage
 
@@ -54,4 +67,7 @@ time to reconfigure. A `models` subcommand lists discovered models.
 
 Optionally specify an adapter path with `--adapter` to apply LoRA weights if the
 `peft` package is available.
+
+If the selected model cannot be loaded an error is printed and the program
+terminates so you always know when something is wrong.
 

--- a/forgeengine/cli.py
+++ b/forgeengine/cli.py
@@ -6,6 +6,7 @@ import os
 from typing import List
 
 from .engine import NarrativeEngine, PRIMARY_MODEL
+from .memory import MemoryStore
 
 
 CONFIG_PATH = os.path.expanduser("~/.forgengine.json")
@@ -68,13 +69,17 @@ def load_config(path: str = CONFIG_PATH, force_setup: bool = False) -> dict:
 
 
 def run_chat(args: argparse.Namespace) -> None:
-    engine = NarrativeEngine(
-        memory_path=args.memory,
-        think_interval=args.think,
-        model_name=args.model,
-        max_tokens=args.max_tokens,
-        adapter_path=args.adapter,
-    )
+    try:
+        engine = NarrativeEngine(
+            memory_path=args.memory,
+            think_interval=args.think,
+            model_name=args.model,
+            max_tokens=args.max_tokens,
+            adapter_path=args.adapter,
+        )
+    except Exception as exc:
+        print(f"Failed to start engine: {exc}")
+        return
     engine._reset_timer()
     print("Type 'quit' or 'exit' to stop.")
     try:
@@ -90,38 +95,20 @@ def run_chat(args: argparse.Namespace) -> None:
 
 
 def show_memory(args: argparse.Namespace) -> None:
-    engine = NarrativeEngine(
-        memory_path=args.memory,
-        think_interval=args.think,
-        model_name=args.model,
-        max_tokens=args.max_tokens,
-        adapter_path=args.adapter,
-    )
-    for item in engine.store.data.interactions:
+    store = MemoryStore(args.memory)
+    for item in store.data.interactions:
         print(f"{item['timestamp']}: {item['user']} -> {item['response']}")
 
 
 def show_events(args: argparse.Namespace) -> None:
-    engine = NarrativeEngine(
-        memory_path=args.memory,
-        think_interval=args.think,
-        model_name=args.model,
-        max_tokens=args.max_tokens,
-        adapter_path=args.adapter,
-    )
-    for evt in engine.store.data.events:
+    store = MemoryStore(args.memory)
+    for evt in store.data.events:
         print(f"{evt['timestamp']}: {evt['event']}")
 
 
 def show_glossary(args: argparse.Namespace) -> None:
-    engine = NarrativeEngine(
-        memory_path=args.memory,
-        think_interval=args.think,
-        model_name=args.model,
-        max_tokens=args.max_tokens,
-        adapter_path=args.adapter,
-    )
-    for word, count in sorted(engine.store.data.glossary.items()):
+    store = MemoryStore(args.memory)
+    for word, count in sorted(store.data.glossary.items()):
         print(f"{word}: {count}")
 
 def list_models(args: argparse.Namespace) -> None:

--- a/install.sh
+++ b/install.sh
@@ -1,0 +1,9 @@
+
+#!/usr/bin/env bash
+set -e
+
+python3 -m venv .venv
+source .venv/bin/activate
+pip install --upgrade pip
+pip install -e .[dev]
+echo "Virtual environment created. Activate with 'source .venv/bin/activate'"

--- a/tests/test_engine.py
+++ b/tests/test_engine.py
@@ -1,13 +1,22 @@
 import sys, pathlib; sys.path.append(str(pathlib.Path(__file__).resolve().parents[1]))
+from forgeengine import engine as eng
 from forgeengine.engine import NarrativeEngine
 
 
-def test_engine_response(tmp_path):
-    engine = NarrativeEngine(
-        memory_path=str(tmp_path / "mem.json"),
-        model_name="sshleifer/tiny-gpt2",
+def test_engine_response(tmp_path, monkeypatch):
+    def dummy_from_pretrained(name, *a, **k):
+        return object()
+
+    monkeypatch.setattr(eng, "AutoTokenizer", type("T", (), {"from_pretrained": dummy_from_pretrained}))
+    monkeypatch.setattr(eng, "AutoModelForCausalLM", type("M", (), {"from_pretrained": dummy_from_pretrained}))
+    monkeypatch.setattr(
+        eng,
+        "pipeline",
+        lambda *args, **kwargs: lambda txt, **kw: [{"generated_text": txt.upper()}],
     )
+
+    engine = NarrativeEngine(memory_path=str(tmp_path / "mem.json"), model_name="dummy")
     response = engine.respond("hello")
-    assert "hello" in response
+    assert "HELLO" in response
 
 


### PR DESCRIPTION
## Summary
- enforce model loading and remove echo fallback
- allow injecting a custom pipeline for testing
- simplify CLI subcommands so model isn't loaded unnecessarily
- add helper installer script and document setup
- update tests for new behavior

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_b_684df81fc7488323abeab02ca120e433